### PR TITLE
Migrate to pytest

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,38 @@
+name: Benchmark
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run pytest-benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up PDM
+        uses: pdm-project/setup-pdm@v3
+        with:
+          python-version: "3.11"
+      - name: Run benchmark
+        run: |
+          pdm install
+          pdm run pytest --benchmark-json output.json
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Python Benchmark with pytest-benchmark
+          tool: 'pytest'
+          output-file-path: output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '200%'
+          comment-on-alert: true
+          summary-always: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@andnp'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,18 @@ jobs:
       run: |
         pdm install
 
-    - name: Publish
+    - name: Build
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       run: pdm run ./scripts/publish.sh
+
+    - name: Publish
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+          password: ${{ secrets.PYPI_TOKEN }}
+
+    - name: Tag
+      run: |
+        git push
+        git push --tags

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 .token
 .pdm-python
 .venv
+.pytest_cache
+.benchmarks
 
 env/
 dist/

--- a/pdm.lock
+++ b/pdm.lock
@@ -320,7 +320,7 @@ summary = "A small Python package for determining appropriate platform-specific 
 
 [[package]]
 name = "pre-commit"
-version = "3.3.1"
+version = "3.3.2"
 requires_python = ">=3.8"
 summary = "A framework for managing and maintaining multi-language pre-commit hooks."
 dependencies = [
@@ -1181,9 +1181,9 @@ content_hash = "sha256:fce8893daa03e54346c0f86b7788d6a4327baa82954920b8c50f9a14d
     {url = "https://files.pythonhosted.org/packages/c1/c7/9be9d651b93efce682b45142a6267034fc4215972780748618c02e236361/platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
     {url = "https://files.pythonhosted.org/packages/cf/4d/198b7e6c6c2b152f4f9f4cdf975d3590e33e63f1920f2d89af7f0390e6db/platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
 ]
-"pre-commit 3.3.1" = [
-    {url = "https://files.pythonhosted.org/packages/77/39/86e07f4e9671ee9311fa4bafc41c66d6a907192707160e3f45272e78be38/pre_commit-3.3.1-py2.py3-none-any.whl", hash = "sha256:218e9e3f7f7f3271ebc355a15598a4d3893ad9fc7b57fe446db75644543323b9"},
-    {url = "https://files.pythonhosted.org/packages/f6/f9/fd40593d83357bb03733c0e77e71a08f2f5f523595d0a10401d7e5c22f16/pre_commit-3.3.1.tar.gz", hash = "sha256:733f78c9a056cdd169baa6cd4272d51ecfda95346ef8a89bf93712706021b907"},
+"pre-commit 3.3.2" = [
+    {url = "https://files.pythonhosted.org/packages/21/55/fccc69a49b66c54dcb9a7d8620131a2566db973837c6611b516a2d4e87d7/pre_commit-3.3.2.tar.gz", hash = "sha256:66e37bec2d882de1f17f88075047ef8962581f83c234ac08da21a0c58953d1f0"},
+    {url = "https://files.pythonhosted.org/packages/45/30/c3d5d192b97de482b9adfa356724dfbb07e293b54d94c3b98dd2e5f24759/pre_commit-3.3.2-py2.py3-none-any.whl", hash = "sha256:8056bc52181efadf4aac792b1f4f255dfd2fb5a350ded7335d251a68561e8cb6"},
 ]
 "prompt-toolkit 3.0.36" = [
     {url = "https://files.pythonhosted.org/packages/eb/37/791f1a6edd13c61cac85282368aa68cb0f3f164440fdf60032f2cc6ca34e/prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -110,6 +110,12 @@ requires_python = ">=3.7"
 summary = "Docutils -- Python Documentation Utilities"
 
 [[package]]
+name = "exceptiongroup"
+version = "1.1.1"
+requires_python = ">=3.7"
+summary = "Backport of PEP 654 (exception groups)"
+
+[[package]]
 name = "filelock"
 version = "3.9.0"
 requires_python = ">=3.7"
@@ -152,6 +158,12 @@ summary = "Read metadata from Python packages"
 dependencies = [
     "zipp>=0.5",
 ]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+requires_python = ">=3.7"
+summary = "brain-dead simple config-ini parsing"
 
 [[package]]
 name = "jaraco-classes"
@@ -319,6 +331,12 @@ requires_python = ">=3.7"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 
 [[package]]
+name = "pluggy"
+version = "1.0.0"
+requires_python = ">=3.6"
+summary = "plugin and hook calling mechanisms for python"
+
+[[package]]
 name = "pre-commit"
 version = "3.3.2"
 requires_python = ">=3.8"
@@ -339,6 +357,11 @@ summary = "Library for building powerful interactive command lines in Python"
 dependencies = [
     "wcwidth",
 ]
+
+[[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+summary = "Get CPU info with pure Python"
 
 [[package]]
 name = "pycodestyle"
@@ -369,6 +392,30 @@ name = "pyparsing"
 version = "3.0.9"
 requires_python = ">=3.6.8"
 summary = "pyparsing module - Classes and methods to define and execute parsing grammars"
+
+[[package]]
+name = "pytest"
+version = "7.3.2"
+requires_python = ">=3.7"
+summary = "pytest: simple powerful testing with Python"
+dependencies = [
+    "colorama; sys_platform == \"win32\"",
+    "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
+    "iniconfig",
+    "packaging",
+    "pluggy<2.0,>=0.12",
+    "tomli>=1.0.0; python_version < \"3.11\"",
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "4.0.0"
+requires_python = ">=3.7"
+summary = "A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer."
+dependencies = [
+    "py-cpuinfo",
+    "pytest>=3.8",
+]
 
 [[package]]
 name = "python-dateutil"
@@ -556,7 +603,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 lock_version = "4.2"
 cross_platform = true
 groups = ["default", "dev"]
-content_hash = "sha256:fce8893daa03e54346c0f86b7788d6a4327baa82954920b8c50f9a14df9052da"
+content_hash = "sha256:50478b6ad16d2c30c975749268a1bb8c0b06a1b48d030628515b9d5a69170609"
 
 [metadata.files]
 "argcomplete 2.0.0" = [
@@ -751,6 +798,10 @@ content_hash = "sha256:fce8893daa03e54346c0f86b7788d6a4327baa82954920b8c50f9a14d
     {url = "https://files.pythonhosted.org/packages/6b/5c/330ea8d383eb2ce973df34d1239b3b21e91cd8c865d21ff82902d952f91f/docutils-0.19.tar.gz", hash = "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6"},
     {url = "https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
 ]
+"exceptiongroup 1.1.1" = [
+    {url = "https://files.pythonhosted.org/packages/61/97/17ed81b7a8d24d8f69b62c0db37abbd8c0042d4b3fc429c73dab986e7483/exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
+    {url = "https://files.pythonhosted.org/packages/cc/38/57f14ddc8e8baeddd8993a36fe57ce7b4ba174c35048b9a6d270bb01e833/exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
+]
 "filelock 3.9.0" = [
     {url = "https://files.pythonhosted.org/packages/0b/dc/eac02350f06c6ed78a655ceb04047df01b02c6b7ea3fc02d4df24ca87d24/filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de"},
     {url = "https://files.pythonhosted.org/packages/14/4c/b201d0292ca4e0950f0741212935eac9996f69cd66b92a3587e594999163/filelock-3.9.0-py3-none-any.whl", hash = "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d"},
@@ -774,6 +825,10 @@ content_hash = "sha256:fce8893daa03e54346c0f86b7788d6a4327baa82954920b8c50f9a14d
 "importlib-metadata 6.0.0" = [
     {url = "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl", hash = "sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad"},
     {url = "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz", hash = "sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d"},
+]
+"iniconfig 2.0.0" = [
+    {url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+    {url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
 ]
 "jaraco-classes 3.2.3" = [
     {url = "https://files.pythonhosted.org/packages/60/28/220d3ae0829171c11e50dded4355d17824d60895285631d7eb9dee0ab5e5/jaraco.classes-3.2.3-py3-none-any.whl", hash = "sha256:2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158"},
@@ -1181,6 +1236,10 @@ content_hash = "sha256:fce8893daa03e54346c0f86b7788d6a4327baa82954920b8c50f9a14d
     {url = "https://files.pythonhosted.org/packages/c1/c7/9be9d651b93efce682b45142a6267034fc4215972780748618c02e236361/platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
     {url = "https://files.pythonhosted.org/packages/cf/4d/198b7e6c6c2b152f4f9f4cdf975d3590e33e63f1920f2d89af7f0390e6db/platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
 ]
+"pluggy 1.0.0" = [
+    {url = "https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {url = "https://files.pythonhosted.org/packages/a1/16/db2d7de3474b6e37cbb9c008965ee63835bba517e22cdb8c35b5116b5ce1/pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
 "pre-commit 3.3.2" = [
     {url = "https://files.pythonhosted.org/packages/21/55/fccc69a49b66c54dcb9a7d8620131a2566db973837c6611b516a2d4e87d7/pre_commit-3.3.2.tar.gz", hash = "sha256:66e37bec2d882de1f17f88075047ef8962581f83c234ac08da21a0c58953d1f0"},
     {url = "https://files.pythonhosted.org/packages/45/30/c3d5d192b97de482b9adfa356724dfbb07e293b54d94c3b98dd2e5f24759/pre_commit-3.3.2-py2.py3-none-any.whl", hash = "sha256:8056bc52181efadf4aac792b1f4f255dfd2fb5a350ded7335d251a68561e8cb6"},
@@ -1188,6 +1247,10 @@ content_hash = "sha256:fce8893daa03e54346c0f86b7788d6a4327baa82954920b8c50f9a14d
 "prompt-toolkit 3.0.36" = [
     {url = "https://files.pythonhosted.org/packages/eb/37/791f1a6edd13c61cac85282368aa68cb0f3f164440fdf60032f2cc6ca34e/prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305"},
     {url = "https://files.pythonhosted.org/packages/fb/93/180be2342f89f16543ec4eb3f25083b5b84eba5378f68efff05409fb39a9/prompt_toolkit-3.0.36.tar.gz", hash = "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63"},
+]
+"py-cpuinfo 9.0.0" = [
+    {url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690"},
+    {url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5"},
 ]
 "pycodestyle 2.10.0" = [
     {url = "https://files.pythonhosted.org/packages/06/6b/5ca0d12ef7dcf7d20dfa35287d02297f3e0f9e515da5183654c03a9636ce/pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
@@ -1208,6 +1271,14 @@ content_hash = "sha256:fce8893daa03e54346c0f86b7788d6a4327baa82954920b8c50f9a14d
 "pyparsing 3.0.9" = [
     {url = "https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {url = "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+"pytest 7.3.2" = [
+    {url = "https://files.pythonhosted.org/packages/58/2a/07c65fdc40846ecb8a9dcda2c38fcb5a06a3e39d08d4a4960916431951cb/pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
+    {url = "https://files.pythonhosted.org/packages/7a/d0/de969198293cdea22b3a6fb99a99aeeddb7b3827f0823b33c5dc0734bbe5/pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
+]
+"pytest-benchmark 4.0.0" = [
+    {url = "https://files.pythonhosted.org/packages/28/08/e6b0067efa9a1f2a1eb3043ecd8a0c48bfeb60d3255006dcc829d72d5da2/pytest-benchmark-4.0.0.tar.gz", hash = "sha256:fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1"},
+    {url = "https://files.pythonhosted.org/packages/4d/a1/3b70862b5b3f830f0422844f25a823d0470739d994466be9dbbbb414d85a/pytest_benchmark-4.0.0-py3-none-any.whl", hash = "sha256:fdb7db64e31c8b277dff9850d2a2556d8b60bcb0ea6524e36e28ffd7c87f71d6"},
 ]
 "python-dateutil 2.8.2" = [
     {url = "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dev = [
     "pre-commit",
     "matplotlib",
     "twine",
+    "pytest>=7.3.2",
+    "pytest-benchmark>=4.0.0",
 ]
 
 [tool.mypy]

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -16,7 +16,3 @@ cz bump --no-verify --yes --check-consistency
 
 # push to pypi repository
 pdm build
-python -m twine upload -u __token__ -p ${PYPI_TOKEN} --non-interactive dist/*
-
-git push
-git push --tags

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 set -e
 mypy -p ReplayTables
-
-export PYTHONPATH=ReplayTables
-python3 -m unittest discover -p "*test_*.py"
+pytest

--- a/tests/test_LagBuffer.py
+++ b/tests/test_LagBuffer.py
@@ -1,4 +1,3 @@
-import unittest
 from typing import Any, Optional
 from dataclasses import dataclass
 
@@ -13,7 +12,7 @@ class Experience:
     terminal: bool
 
 
-class TestLagBuffer(unittest.TestCase):
+class TestLagBuffer:
     def test_1_step(self):
         buffer = LagBuffer(1)
 
@@ -34,12 +33,11 @@ class TestLagBuffer(unittest.TestCase):
         )
 
         out = list(buffer.add(exp1))
-        self.assertEqual(out, [])
+        assert out == []
 
         out = list(buffer.add(exp2))
-        self.assertEqual(len(out), 1)
-
-        self.assertEqual(out[0], LaggedExperience(
+        assert len(out) == 1
+        assert out[0] == LaggedExperience(
             s=3,
             a=0,
             r=2.,
@@ -47,7 +45,7 @@ class TestLagBuffer(unittest.TestCase):
             terminal=True,
             sp=4,
             raw=exp1,
-        ))
+        )
 
     def test_3_step(self):
         buffer = LagBuffer(3)
@@ -62,7 +60,7 @@ class TestLagBuffer(unittest.TestCase):
                 terminal=False,
             )
             out = list(buffer.add(exp))
-            self.assertEqual(out, [])
+            assert out == []
 
             experiences.append(exp)
 
@@ -74,8 +72,8 @@ class TestLagBuffer(unittest.TestCase):
             terminal=False,
         )
         out = list(buffer.add(exp))
-        self.assertEqual(len(out), 1)
-        self.assertEqual(out[0], LaggedExperience(
+        assert len(out) == 1
+        assert out[0] == LaggedExperience(
             s=1,
             a=0,
             r=4 + (0.9 * 6) + (0.9 ** 2 * 8),
@@ -83,7 +81,7 @@ class TestLagBuffer(unittest.TestCase):
             terminal=False,
             sp=4,
             raw=experiences[0],
-        ))
+        )
 
         term = Experience(
             s=5,
@@ -94,9 +92,9 @@ class TestLagBuffer(unittest.TestCase):
         )
 
         out = list(buffer.add(term))
-        self.assertEqual(len(out), 3)
+        assert len(out) == 3
 
-        self.assertEqual(out[0], LaggedExperience(
+        assert out[0] == LaggedExperience(
             s=2,
             a=1,
             r=6 + (0.9 * 8) + (0.9 ** 2 * 10),
@@ -104,9 +102,9 @@ class TestLagBuffer(unittest.TestCase):
             terminal=True,
             sp=5,
             raw=experiences[1],
-        ))
+        )
 
-        self.assertEqual(out[1], LaggedExperience(
+        assert out[1] == LaggedExperience(
             s=3,
             a=2,
             r=8 + (0.9 * 10),
@@ -114,9 +112,9 @@ class TestLagBuffer(unittest.TestCase):
             terminal=True,
             sp=5,
             raw=experiences[2],
-        ))
+        )
 
-        self.assertEqual(out[2], LaggedExperience(
+        assert out[2] == LaggedExperience(
             s=4,
             a=22,
             r=10,
@@ -124,7 +122,7 @@ class TestLagBuffer(unittest.TestCase):
             terminal=True,
             sp=5,
             raw=exp,
-        ))
+        )
 
     def test_flush(self):
         buffer = LagBuffer(lag=1)
@@ -137,6 +135,6 @@ class TestLagBuffer(unittest.TestCase):
             terminal=True,
         ))
 
-        self.assertEqual(len(buffer._buffer), 1)
+        assert len(buffer._buffer) == 1
         buffer.flush()
-        self.assertEqual(len(buffer._buffer), 0)
+        assert len(buffer._buffer) == 0

--- a/tests/test_PER.py
+++ b/tests/test_PER.py
@@ -1,4 +1,3 @@
-import unittest
 import pickle
 import numpy as np
 from typing import cast, NamedTuple
@@ -11,44 +10,44 @@ class Data(NamedTuple):
     b: int
 
 
-class TestPER(unittest.TestCase):
+class TestPER:
     def test_simple_buffer(self):
         rng = np.random.default_rng(0)
         buffer = PrioritizedReplay(5, Data, rng)
 
         # on creation, the buffer should have no size
-        self.assertEqual(buffer.size(), 0)
+        assert buffer.size() == 0
 
         # should be able to simply add and sample a single data point
         d = Data(a=0.1, b=1)
         buffer.add(d)
-        self.assertEqual(buffer.size(), 1)
+        assert buffer.size() == 1
         samples, idxs, weights = buffer.sample(10)
-        self.assertTrue(np.all(samples.b == 1))
-        self.assertTrue(np.all(idxs == 0))
-        self.assertTrue(np.all(weights == 0.2))
+        assert np.all(samples.b == 1)
+        assert np.all(idxs == 0)
+        assert np.all(weights == 0.2)
 
         # should be able to add a few more points
         for i in range(4):
             x = i + 2
             buffer.add(Data(a=x / 10, b=x))
 
-        self.assertEqual(buffer.size(), 5)
+        assert buffer.size() == 5
         samples, idxs, weights = buffer.sample(1000)
 
         unique = np.unique(samples.b)
         unique.sort()
 
-        self.assertTrue(np.all(unique == np.array([1, 2, 3, 4, 5])))
+        assert np.all(unique == np.array([1, 2, 3, 4, 5]))
 
         # buffer drops the oldest element when over max size
         buffer.add(Data(a=0.6, b=6))
-        self.assertEqual(buffer.size(), 5)
+        assert buffer.size() == 5
 
         samples, _, _ = buffer.sample(1000)
         unique = np.unique(samples.b)
         unique.sort()
-        self.assertTrue(np.all(unique == np.array([2, 3, 4, 5, 6])))
+        assert np.all(unique == np.array([2, 3, 4, 5, 6]))
 
     def test_priority_on_add(self):
         rng = np.random.default_rng(0)
@@ -64,8 +63,8 @@ class TestPER(unittest.TestCase):
         b = np.sum(batch.b == 2)
         a = np.sum(batch.b == 1)
 
-        self.assertEqual(b, 91)
-        self.assertEqual(a, 37)
+        assert b == 91
+        assert a == 37
 
     def test_pickeable(self):
         rng = np.random.default_rng(0)
@@ -83,4 +82,35 @@ class TestPER(unittest.TestCase):
         s, _, _ = buffer.sample(20)
         s2, _, _ = buffer2.sample(20)
 
-        self.assertTrue(np.all(s.a == s2.a) and np.all(s.b == s2.b))
+        assert np.all(s.a == s2.a) and np.all(s.b == s2.b)
+
+
+# ----------------
+# -- Benchmarks --
+# ----------------
+class TestBenchmarks:
+    def test_per_add(self, benchmark):
+        rng = np.random.default_rng(0)
+        buffer = PrioritizedReplay(100_000, Data, rng)
+        d = Data(a=0.1, b=1)
+
+        for i in range(100_000):
+            buffer.add(d, priority=2 * i + 1)
+
+        def _inner(buffer: PrioritizedReplay, d: Data):
+            buffer.add(d, priority=1)
+
+        benchmark(_inner, buffer, d)
+
+    def test_per_sample(self, benchmark):
+        rng = np.random.default_rng(0)
+        buffer = PrioritizedReplay(100_000, Data, rng)
+        d = Data(a=0.1, b=1)
+
+        for i in range(100_000):
+            buffer.add(d, priority=2 * i + 1)
+
+        def _inner(buffer: PrioritizedReplay):
+            buffer.sample(32)
+
+        benchmark(_inner, buffer)

--- a/tests/test_PrioritizedHeap.py
+++ b/tests/test_PrioritizedHeap.py
@@ -1,4 +1,3 @@
-import unittest
 import numpy as np
 from typing import NamedTuple
 
@@ -8,7 +7,7 @@ class Data(NamedTuple):
     a: float | np.ndarray
     b: int | np.ndarray
 
-class TestPrioritizedHeap(unittest.TestCase):
+class TestPrioritizedHeap:
     def test_simple_buffer(self):
         rng = np.random.default_rng(0)
 
@@ -20,29 +19,65 @@ class TestPrioritizedHeap(unittest.TestCase):
 
         # low priority items are not added
         buffer.add(Data(1, 2), priority=0.1)
-        self.assertEqual(buffer.size(), 0)
+        assert buffer.size() == 0
 
         # high priority items are added
         buffer.add(Data(2, 3), priority=2)
-        self.assertEqual(buffer.size(), 1)
+        assert buffer.size() == 1
 
         # items can be popped
         item = buffer.pop()
-        self.assertEqual(item, Data(2, 3))
-        self.assertEqual(buffer.size(), 0)
+        assert item == Data(2, 3)
+        assert buffer.size() == 0
 
         # many items can be added
         for i in range(30):
             buffer.add(Data(i, 2 * i), priority=(i - 14) ** 2)
 
-        self.assertEqual(buffer.size(), 10)
+        assert buffer.size() == 10
 
         item = buffer.pop()
-        self.assertEqual(item, Data(29, 58))
-        self.assertEqual(buffer.size(), 9)
+        assert item == Data(29, 58)
+        assert buffer.size() == 9
 
         # can sample a batch from the buffer
         batch, _, _ = buffer.sample(5)
-        self.assertEqual(np.asarray(batch.a).size, 5)
-        self.assertTrue(np.all(batch.a == np.array([28, 0, 1, 27, 26])))
-        self.assertEqual(buffer.size(), 4)
+        assert np.asarray(batch.a).size == 5
+        assert np.all(batch.a == np.array([28, 0, 1, 27, 26]))
+        assert buffer.size() == 4
+
+# ----------------
+# -- Benchmarks --
+# ----------------
+
+class TestBenchmarks:
+    def test_prioritized_heap_add(self, benchmark):
+        rng = np.random.default_rng(0)
+        buffer = PrioritizedHeap(
+            max_size=100_000,
+            structure=Data,
+            rng=rng,
+        )
+        d = Data(0.1, 1)
+
+        def _inner(buffer, d):
+            buffer.add(d, priority=2)
+
+        benchmark(_inner, buffer, d)
+
+    def test_prioritized_heap_sample(self, benchmark):
+        rng = np.random.default_rng(0)
+        buffer = PrioritizedHeap(
+            max_size=100_000,
+            structure=Data,
+            rng=rng,
+        )
+        d = Data(0.1, 1)
+
+        for i in range(100_000):
+            buffer.add(d, priority=i)
+
+        def _inner(buffer):
+            buffer.sample(32)
+
+        benchmark(_inner, buffer)

--- a/tests/test_Table.py
+++ b/tests/test_Table.py
@@ -1,9 +1,8 @@
-import unittest
 import numpy as np
 
 from ReplayTables.Table import Table
 
-class TestTable(unittest.TestCase):
+class TestTable:
     def test_canAddMultipleColumns(self):
         table = Table(3, seed=0, columns=[
             { 'name': 'A', 'shape': 3 },
@@ -19,15 +18,15 @@ class TestTable(unittest.TestCase):
 
         A, B, C = table.getAll()
 
-        self.assertTrue(np.allclose(A, np.array([
+        assert np.allclose(A, [
             [0, 3.3, 6.6],
             [0, 4.4, 8.8],
             [0, 5.5, 11],
-        ])))
+        ])
 
-        self.assertTrue(np.all(B == [[True], [True], [False]]))
+        assert np.all(B == [[True], [True], [False]])
 
-        self.assertTrue(np.allclose(C, [3, 4, 5]))
+        assert np.allclose(C, [3, 4, 5])
 
     def test_canSampleTable(self):
         table = Table(3, seed=1, columns=[
@@ -39,13 +38,13 @@ class TestTable(unittest.TestCase):
             table.addTuple((np.arange(3) * i, i**2))
 
         A, B = table.sample()
-        self.assertTrue(np.allclose(A, [[0, 6, 12]]))
-        self.assertTrue(np.allclose(B, [36]))
+        assert np.allclose(A, [[0, 6, 12]])
+        assert np.allclose(B, [36])
 
         A, B = table.sample(3)
-        self.assertTrue(np.allclose(A, [
+        assert np.allclose(A, [
             [0, 5, 10],
             [0, 6, 12],
             [0, 7, 14],
-        ]))
-        self.assertTrue(np.allclose(B, [25, 36, 49]))
+        ])
+        assert np.allclose(B, [25, 36, 49])

--- a/tests/test_View.py
+++ b/tests/test_View.py
@@ -1,9 +1,9 @@
-import unittest
+import pytest
 import numpy as np
 
 from ReplayTables.Table import Table, View
 
-class TestView(unittest.TestCase):
+class TestView:
     def test_getAllSequences(self):
         table = Table(7, seed=0, columns=[
             { 'name': 'A', 'shape': 3 },
@@ -19,11 +19,11 @@ class TestView(unittest.TestCase):
 
         A, B, C = view.getAll()
 
-        self.assertEqual(A.shape, (7, 3, 3))
-        self.assertEqual(B.shape, (7, 3, 1))
-        self.assertEqual(C.shape, (7, 3))
+        assert A.shape == (7, 3, 3)
+        assert B.shape == (7, 3, 1)
+        assert C.shape == (7, 3)
 
-        self.assertTrue(np.allclose(C, [
+        assert np.allclose(C, [
             # n_t, n_{t+1}, n_{t+2}
             [13, 14, 15],
             [14, 15, 16],
@@ -34,11 +34,12 @@ class TestView(unittest.TestCase):
             # these are padded with np.nan for floats and 0 for ints (by default, configurable)
             [18, 19, 0 ],
             [19, 0, 0 ],
-        ]))
+        ])
 
         # if we try to add a view to a table that already has data
         # that is undefined behavior and so through an error
-        self.assertRaises(Exception, lambda: View(table, 4))
+        with pytest.raises(Exception):
+            View(table, 4)
 
     def test_customPad(self):
         table = Table(7, seed=0, columns=[
@@ -55,11 +56,11 @@ class TestView(unittest.TestCase):
 
         A, B, C = view.getAll()
 
-        self.assertEqual(A.shape, (7, 3, 3))
-        self.assertEqual(B.shape, (7, 3, 1))
-        self.assertEqual(C.shape, (7, 3))
+        assert A.shape, (7, 3, 3)
+        assert B.shape, (7, 3, 1)
+        assert C.shape, (7, 3)
 
-        self.assertTrue(np.allclose(C, [
+        assert np.allclose(C, [
             [13, 14, 15],
             [14, 15, 16],
             [15, 16, 17],
@@ -67,7 +68,7 @@ class TestView(unittest.TestCase):
             [17, 18, 19],
             [18, 19, -22],
             [19, -22, -22],
-        ]))
+        ])
 
     def test_endSequence(self):
         # if a sequence terminates during the stream
@@ -92,7 +93,7 @@ class TestView(unittest.TestCase):
                 table.endTrajectory()
 
         A, B, C = view3.getAll()
-        self.assertTrue(np.allclose(C, [
+        assert np.allclose(C, [
             [13, 14, 15],
             [14, 15, 0],
             [15, 0, 0],
@@ -100,10 +101,10 @@ class TestView(unittest.TestCase):
             [17, 18, 19],
             [18, 19, 0],
             [19, 0, 0],
-        ]))
+        ])
 
         A, B, C = view5.getAll()
-        self.assertTrue(np.allclose(C, [
+        assert np.allclose(C, [
             [13, 14, 15, 0, 0],
             [14, 15, 0, 0, 0],
             [15, 0, 0, 0, 0],
@@ -111,7 +112,7 @@ class TestView(unittest.TestCase):
             [17, 18, 19, 0, 0],
             [18, 19, 0, 0, 0],
             [19, 0, 0, 0, 0],
-        ]))
+        ])
 
     def test_sample(self):
         table = Table(7, seed=0, columns=[
@@ -137,17 +138,17 @@ class TestView(unittest.TestCase):
         # we collected trajectories of length 3 (i.e. 3-step trajectories)
         # now I want 2 of those trajectories sampled at random
         A, B, C = view3.sample(2)
-        self.assertTrue(np.allclose(C, [
+        assert np.allclose(C, [
             [17, 18, 19],
             [15, 0, 0],
-        ]))
+        ])
 
         A, B, C = view5.sample(3)
-        self.assertTrue(np.allclose(C, [
+        assert np.allclose(C, [
             [15, 0, 0, 0, 0],
             [16, 17, 18, 19, 0],
             [15, 0, 0, 0, 0],
-        ]))
+        ])
 
     def test_getLastComplete(self):
         table = Table(7, seed=0, columns=[
@@ -169,10 +170,10 @@ class TestView(unittest.TestCase):
 
         # this should be the last *complete* trajectory
         A, B, C = view3.getLastComplete()
-        self.assertTrue(np.allclose(C, [17, 18, 19]))
+        assert np.allclose(C, [17, 18, 19])
 
         A, B, C = view5.getLastComplete()
-        self.assertTrue(np.allclose(C, [16, 17, 18, 19, 0]))
+        assert np.allclose(C, [16, 17, 18, 19, 0])
 
         A, B, C = view5.getLastComplete(offset=1)
-        self.assertTrue(np.allclose(C, [17, 18, 19, 0, 0]))
+        assert np.allclose(C, [17, 18, 19, 0, 0])

--- a/tests/utils/test_MinMaxHeap.py
+++ b/tests/utils/test_MinMaxHeap.py
@@ -1,51 +1,50 @@
-import unittest
 from ReplayTables._utils.MinMaxHeap import MinMaxHeap
 
-class TestMinMaxHeap(unittest.TestCase):
+class TestMinMaxHeap:
     def test_can_track_stats(self):
         h = MinMaxHeap()
 
         h.add(1, 'a')
         p, got = h.min()
-        self.assertEqual(p, 1)
-        self.assertEqual(got, 'a')
+        assert p == 1
+        assert got == 'a'
 
         p, got = h.max()
-        self.assertEqual(p, 1)
-        self.assertEqual(got, 'a')
+        assert p == 1
+        assert got == 'a'
 
         h.add(3, 'b')
         p, got = h.min()
-        self.assertEqual(p, 1)
-        self.assertEqual(got, 'a')
+        assert p == 1
+        assert got == 'a'
 
         p, got = h.max()
-        self.assertEqual(p, 3)
-        self.assertEqual(got, 'b')
+        assert p == 3
+        assert got == 'b'
 
         for i in range(33):
             h.add(i, f'{i}')
 
         p, got = h.min()
-        self.assertEqual(p, 0)
-        self.assertEqual(got, '0')
+        assert p == 0
+        assert got == '0'
 
         p, got = h.max()
-        self.assertEqual(p, 32)
-        self.assertEqual(got, '32')
+        assert p == 32
+        assert got == '32'
 
         p, got = h.pop_min()
-        self.assertEqual(p, 0)
-        self.assertEqual(got, '0')
+        assert p == 0
+        assert got == '0'
 
         p, got = h.pop_min()
-        self.assertEqual(p, 1)
-        self.assertEqual(got, '1')
+        assert p == 1
+        assert got == '1'
 
         p, got = h.pop_max()
-        self.assertEqual(p, 32)
-        self.assertEqual(got, '32')
+        assert p == 32
+        assert got == '32'
 
         p, got = h.pop_max()
-        self.assertEqual(p, 31)
-        self.assertEqual(got, '31')
+        assert p == 31
+        assert got == '31'


### PR DESCRIPTION
I like the benchmark plugins in pytest. This PR moves over to pytest and adds several basic benchmarks. Benchmarks effectively double as integration tests, where the primary goal is benchmarking the standard, expected use cases.