### PR TITLE
Adds the ability to "delete" samples for PER

### DIFF
--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -25,7 +25,7 @@ jobs:
           tool: 'pytest'
           output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '20%'
+          alert-threshold: '40%'
           comment-on-alert: true
           summary-always: true
           fail-on-alert: true

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -1,12 +1,7 @@
 name: Benchmark
 on:
-  push:
-    branches:
-      - main
-
-permissions:
-  contents: write
-  deployments: write
+  pull_request:
+    branches: [ main ]
 
 jobs:
   benchmark:
@@ -30,4 +25,8 @@ jobs:
           tool: 'pytest'
           output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
+          alert-threshold: '20%'
+          comment-on-alert: true
+          summary-always: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@andnp'

--- a/ReplayTables/PER.py
+++ b/ReplayTables/PER.py
@@ -1,7 +1,7 @@
 import numpy as np
 from dataclasses import dataclass
 from typing import cast, Any, Optional, Type
-from ReplayTables.ReplayBuffer import ReplayBufferInterface, EIDS, T
+from ReplayTables.ReplayBuffer import ReplayBufferInterface, EID, EIDS, T
 from ReplayTables.Distributions import MixinUniformDistribution, MixtureDistribution, PrioritizedDistribution, SubDistribution, UniformDistribution
 
 @dataclass
@@ -62,3 +62,10 @@ class PrioritizedReplay(ReplayBufferInterface[T]):
             self._c.max_decay * self._max_priority,
             priorities.max(),
         )
+
+    def delete_sample(self, eid: EID):
+        idx = np.array([eid])
+        zero = np.zeros(1)
+
+        self._p_dist.update(idx, zero)
+        self._uniform.update(idx, zero)

--- a/tests/test_PER.py
+++ b/tests/test_PER.py
@@ -2,7 +2,7 @@ import pickle
 import numpy as np
 from typing import cast, NamedTuple
 
-from ReplayTables.ReplayBuffer import EIDS
+from ReplayTables.ReplayBuffer import EID, EIDS
 from ReplayTables.PER import PrioritizedReplay
 
 class Data(NamedTuple):
@@ -84,6 +84,20 @@ class TestPER:
 
         assert np.all(s.a == s2.a) and np.all(s.b == s2.b)
 
+    def test_delete_sample(self):
+        rng = np.random.default_rng(0)
+        buffer = PrioritizedReplay(5, Data, rng)
+
+        for i in range(5):
+            buffer.add(Data(i, 2 * i))
+
+        batch, _, _, = buffer.sample(512)
+        assert np.unique(batch.a).shape == (5,)
+
+        buffer.delete_sample(cast(EID, 2))
+        batch, _, _ = buffer.sample(512)
+        assert np.unique(batch.a).shape == (4,)
+        assert 2 not in batch.a
 
 # ----------------
 # -- Benchmarks --


### PR DESCRIPTION
This is a first pass at using "masking" in the sampling layer in order to prevent samples from being used, without deleting the underlying data. This way when we break samples into smaller temporal chunks, we don't have  to worry about deleting a timestep that other samples depend on.

This PR also changes the benchmarking workflow to prevent benchmark results from being stored from within PRs.