### PR TITLE
Storage rework

### DIFF
--- a/ReplayTables/ReplayBuffer.py
+++ b/ReplayTables/ReplayBuffer.py
@@ -56,6 +56,10 @@ class ReplayBufferInterface:
         last: Any = self._t - 1
         return last
 
+    def use_storage(self, storage: Storage):
+        assert self._max_size <= storage.max_size
+        self._storage = storage
+
     @abstractmethod
     def _on_add(self, transition: LaggedTimestep): ...
 

--- a/ReplayTables/storage/Storage.py
+++ b/ReplayTables/storage/Storage.py
@@ -6,6 +6,10 @@ class Storage:
     def __init__(self, max_size: int):
         self._max_size = max_size
 
+    @property
+    def max_size(self):
+        return self._max_size
+
     @abstractmethod
     def __len__(self) -> int:
         ...

--- a/ReplayTables/storage/Storage.py
+++ b/ReplayTables/storage/Storage.py
@@ -1,9 +1,12 @@
 from abc import abstractmethod
 from typing import Any
-from ReplayTables.interface import Batch, LaggedTimestep, EIDs, IDX, IDXs
+from ReplayTables.interface import Batch, LaggedTimestep, EID, EIDs, IDXs
+from ReplayTables.ingress.IndexMapper import IndexMapper
+from ReplayTables.ingress.CircularMapper import CircularMapper
 
 class Storage:
-    def __init__(self, max_size: int):
+    def __init__(self, max_size: int, idx_mapper: IndexMapper | None = None):
+        self._idx_mapper = idx_mapper or CircularMapper(max_size)
         self._max_size = max_size
 
     @property
@@ -15,23 +18,27 @@ class Storage:
         ...
 
     @abstractmethod
-    def __delitem__(self, idx: IDX):
+    def __delitem__(self, eid: EID):
         ...
 
     @abstractmethod
-    def get(self, idxs: IDXs) -> Batch:
+    def __contains__(self, eid: EID):
         ...
 
     @abstractmethod
-    def get_item(self, idx: IDX) -> LaggedTimestep:
+    def get(self, eids: EIDs) -> Batch:
         ...
 
     @abstractmethod
-    def set(self, idx: IDX, n_idx: IDX | None, transition: LaggedTimestep):
+    def get_item(self, eid: EID) -> LaggedTimestep:
         ...
 
     @abstractmethod
-    def add(self, idx: IDX, n_idx: IDX | None, transition: LaggedTimestep, /, **kwargs: Any) -> None:
+    def set(self, transition: LaggedTimestep):
+        ...
+
+    @abstractmethod
+    def add(self, transition: LaggedTimestep, /, **kwargs: Any) -> None:
         ...
 
     @abstractmethod

--- a/tests/storage/test_BasicStorage.py
+++ b/tests/storage/test_BasicStorage.py
@@ -1,8 +1,7 @@
 import numpy as np
 from typing import cast
 from ReplayTables.storage.BasicStorage import BasicStorage
-from ReplayTables.interface import LaggedTimestep, EID, IDX, IDXs
-from tests._utils.fake_data import fake_lagged_timestep
+from ReplayTables.interface import LaggedTimestep, EID
 
 def test_inferred_types1():
     storage = BasicStorage(10)
@@ -18,15 +17,11 @@ def test_inferred_types1():
         gamma=0.99,
         terminal=False,
         extra={},
-        n_eid=cast(EID, 34),
+        n_eid=None,
         n_x=None,
     )
 
-    storage.add(
-        cast(IDX, 0),
-        None,
-        d,
-    )
+    storage.add(d)
 
     assert storage._state_store.dtype == np.uint8
     assert storage._state_store.shape == (11, 32, 32)
@@ -46,45 +41,12 @@ def test_inferred_types2():
         gamma=0.99,
         terminal=False,
         extra={},
-        n_eid=cast(EID, 34),
+        n_eid=None,
         n_x=None,
     )
 
-    storage.add(
-        cast(IDX, 0),
-        None,
-        d,
-    )
+    storage.add(d)
 
     assert storage._state_store.dtype == np.float32
     assert storage._state_store.shape == (11, 15)
     assert storage._a.dtype == np.int32
-
-def test_add1():
-    storage = BasicStorage(10)
-
-    storage.add(
-        cast(IDX, 0),
-        cast(IDX, 1),
-        fake_lagged_timestep(eid=32, n_eid=34),
-    )
-
-    storage.add(
-        cast(IDX, 1),
-        cast(IDX, 2),
-        fake_lagged_timestep(eid=34, n_eid=36),
-    )
-
-    assert len(storage) == 2
-
-    d = storage.get(cast(IDXs, np.array([1])))
-    assert d.eid == 34
-
-    for i in range(10):
-        storage.add(
-            cast(IDX, (3 + i) % 10),
-            cast(IDX, (4 + i) % 10),
-            fake_lagged_timestep(eid=36 + i, n_eid=38 + i),
-        )
-
-    assert len(storage) == 10

--- a/tests/storage/test_Storage.py
+++ b/tests/storage/test_Storage.py
@@ -1,11 +1,11 @@
 import pytest
 import numpy as np
 
-from typing import cast, Any, Type
+from typing import cast, Type
 from ReplayTables.storage.BasicStorage import Storage, BasicStorage
 from ReplayTables.storage.CompressedStorage import CompressedStorage
 from ReplayTables.storage.NonArrayStorage import NonArrayStorage
-from ReplayTables.interface import IDX, IDXs
+from ReplayTables.interface import EIDs
 
 from tests._utils.fake_data import fake_lagged_timestep
 
@@ -20,26 +20,20 @@ STORAGES = [
 def test_add1(Store: Type[Storage]):
     storage = Store(10)
     storage.add(
-        cast(IDX, 0),
-        cast(IDX, 1),
         fake_lagged_timestep(eid=32, n_eid=34),
     )
 
     storage.add(
-        cast(IDX, 1),
-        cast(IDX, 2),
         fake_lagged_timestep(eid=34, n_eid=36),
     )
 
     assert len(storage) == 2
 
-    d = storage.get(cast(IDXs, np.array([1])))
+    d = storage.get(cast(EIDs, np.array([34])))
     assert d.eid == 34
 
     for i in range(10):
         storage.add(
-            cast(IDX, (3 + i) % 10),
-            cast(IDX, (4 + i) % 10),
             fake_lagged_timestep(eid=36 + i, n_eid=38 + i),
         )
 
@@ -51,20 +45,21 @@ def test_small_data(benchmark, Store: Type[Storage]):
     benchmark.name = Store.__name__
     benchmark.group = 'storage | small data'
 
-    def add_and_get(storage: Storage, timestep, idxs):
+    def add_and_get(storage: Storage, timesteps, eids):
         for i in range(100):
-            idx: Any = i
-            n_idx: Any = 100 + i
-            storage.add(idx, n_idx, timestep)
+            storage.add(timesteps[i])
 
         for i in range(100):
-            storage.get(idxs)
+            storage.get(eids)
 
     storage = Store(10_000)
-    idxs = np.arange(32)
-    d = fake_lagged_timestep(eid=0, n_eid=1, x=np.ones(10), n_x=np.ones(10))
+    eids = np.arange(32)
+    data = [
+        fake_lagged_timestep(eid=2 * i, n_eid=2 * i + 1, x=np.ones(10), n_x=np.ones(10))
+        for i in range(100)
+    ]
 
-    benchmark(add_and_get, storage, d, idxs)
+    benchmark(add_and_get, storage, data, eids)
 
 
 @pytest.mark.parametrize('Store', STORAGES)
@@ -72,18 +67,19 @@ def test_big_data(benchmark, Store: Type[Storage]):
     benchmark.name = Store.__name__
     benchmark.group = 'storage | big data'
 
-    def add_and_get(storage: Storage, timestep, idxs):
+    def add_and_get(storage: Storage, timesteps, eids):
         for i in range(100):
-            idx: Any = i
-            n_idx: Any = 100 + i
-            storage.add(idx, n_idx, timestep)
+            storage.add(timesteps[i])
 
         for i in range(100):
-            storage.get(idxs)
+            storage.get(eids)
 
     storage = Store(10_000)
-    idxs = np.arange(32)
+    eids = np.arange(32)
     x = np.ones((64, 64, 3), dtype=np.uint8)
-    d = fake_lagged_timestep(eid=0, n_eid=1, x=x, n_x=x)
+    data = [
+        fake_lagged_timestep(eid=2 * i, n_eid=2 * i + 1, x=x, n_x=x)
+        for i in range(100)
+    ]
 
-    benchmark(add_and_get, storage, d, idxs)
+    benchmark(add_and_get, storage, data, eids)


### PR DESCRIPTION
This PR does a minor rework of the storage mechanism to use eids on the external interface. This should allow us to use a shared storage between multiple buffers, where each of those buffers might have a different idx->eid mapping. A clear example of this would be having a small "fast" buffer for rapid policy improvement, and a large "slow" buffer for representation learning.