### PR TITLE
Fixup compressed storage

### DIFF
--- a/ReplayTables/_utils/RefCount.py
+++ b/ReplayTables/_utils/RefCount.py
@@ -37,6 +37,9 @@ class RefCount:
         idxs = np.array([self._idxs[xid] for xid in xids], dtype=np.int64)
         return idxs
 
+    def has_xid(self, xid: XID):
+        return xid in self._idxs
+
     def remove_transition(self, eid: EID):
         if eid not in self._eid2xids:
             return

--- a/ReplayTables/storage/BasicStorage.py
+++ b/ReplayTables/storage/BasicStorage.py
@@ -34,7 +34,12 @@ class BasicStorage(Storage):
         if not self._built: self._deferred_init(transition)
 
         # stash metadata
-        item, last_item = self.meta.add_item(eid=transition.eid, idx=idx, xid=transition.xid, n_xid=transition.n_xid)
+        item, last_item = self.meta.add_item(
+            eid=transition.eid,
+            idx=idx,
+            xid=transition.xid,
+            n_xid=transition.n_xid,
+        )
 
         # make room in state storage
         if last_item is not None:
@@ -117,12 +122,14 @@ class BasicStorage(Storage):
         self.delete_item(item)
 
     def delete_item(self, item: Item):
-        self._remove_state(item.sidx)
+        if not self.meta.has_xid(item.xid):
+            self._remove_state(item.sidx)
 
         if item.idx in self._extras:
             del self._extras[item.idx]
 
-        if item.n_sidx is not None:
+        if item.n_xid is not None and not self.meta.has_xid(item.n_xid):
+            assert item.n_sidx is not None
             self._remove_state(item.n_sidx)
 
     def __len__(self):

--- a/ReplayTables/storage/CompressedStorage.py
+++ b/ReplayTables/storage/CompressedStorage.py
@@ -52,8 +52,12 @@ class CompressedStorage(BasicStorage):
             del self._state_store[sidx]
 
     def __getstate__(self):
-        for idx in self._locks: self._wait(idx)
-        return { '_state_store': self._state_store }
+        for idx in list(self._locks): self._wait(idx)
+        d = self.__dict__.copy()
+        del d['_tpe']
+        return d
 
     def __setstate__(self, state):
-        self._state_store = state['_state_store']
+        self.__dict__ = state
+        self._tpe = ThreadPoolExecutor(max_workers=2)
+        self._locks = {}

--- a/ReplayTables/storage/CompressedStorage.py
+++ b/ReplayTables/storage/CompressedStorage.py
@@ -25,6 +25,7 @@ class CompressedStorage(BasicStorage):
         self._a = np.empty(self._max_size, dtype=npu.get_dtype(transition.a))
 
         self._state_store[-1] = lz4.frame.compress(zero_x)
+        self._shape = zero_x.shape
 
     def _wait(self, idx: int):
         if idx in self._locks:
@@ -41,7 +42,7 @@ class CompressedStorage(BasicStorage):
     def _load_state(self, idx: SIDX) -> np.ndarray:
         self._wait(idx)
         raw = lz4.frame.decompress(self._state_store[idx])
-        return np.frombuffer(raw, dtype=self._dtype)
+        return np.frombuffer(raw, dtype=self._dtype).reshape(self._shape)
 
     def _load_states(self, idxs: SIDXs) -> np.ndarray:
         return np.stack([self._load_state(idx) for idx in idxs])

--- a/ReplayTables/storage/MetadataStorage.py
+++ b/ReplayTables/storage/MetadataStorage.py
@@ -77,3 +77,6 @@ class MetadataStorage:
         )
 
         return item, last_item
+
+    def has_xid(self, xid: XID):
+        return self._ref.has_xid(xid)


### PR DESCRIPTION
Fixes the issues of deleting states from storage even though transitions still depend on those states. Found a slightly different way to implement it that still let's us keep a consistent public api for `buffer.delete_item` and avoiding a breaking change.

FYI: @panahiparham