### PR TITLE
Add without replacement sampling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8

--- a/tests/test_ReplayBuffer.py
+++ b/tests/test_ReplayBuffer.py
@@ -50,6 +50,32 @@ class TestReplayBuffer:
         unique.sort()
         assert np.all(unique == np.array([2, 3, 4, 5, 6]))
 
+    def test_without_replacement(self):
+        rng = np.random.default_rng(0)
+        buffer = ReplayBuffer(5, 1, rng)
+
+        # on creation, the buffer should have no size
+        assert buffer.size() == 0
+
+        # should be able to simply add and sample a single data point
+        d = fake_timestep(a=-1, r=None)
+        buffer.add_step(d)
+        assert buffer.size() == 0
+
+        for a in range(5):
+            d = fake_timestep(a=a)
+            buffer.add_step(d)
+
+        assert buffer.size() == 5
+
+        for _ in range(25):
+            batch = buffer.sample_without_replacement(3)
+            assert len(set(batch.a)) == 3
+
+        for _ in range(25):
+            batch = buffer.sample_without_replacement(5)
+            assert len(set(batch.a)) == 5
+
     def test_terminal_states(self):
         rng = np.random.default_rng(0)
         buffer = ReplayBuffer(5, 1, rng)


### PR DESCRIPTION
This change adds a new function to the public API for all replay buffers for sampling without replacement. There are some scenarios where I expect this to not work, such as when the sampling strategy changes distribution immediately after sampling (particularly for walk-back distributions). We don't currently have any of those implemented, so that is a problem for a later time.