### PR TITLE
Lag buffer

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: 'pip'
 
       - name: Run benchmark
         run: |

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: 'pip'
 
       - name: Run benchmark
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,7 +21,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.11"
-        cache: 'pip'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
 
     - name: Install dependencies
       run: |

--- a/ReplayTables/ingress/LagBuffer.py
+++ b/ReplayTables/ingress/LagBuffer.py
@@ -76,14 +76,6 @@ class LagBuffer:
         self.flush()
         return out
 
-    def add_action(self, a: Any):
-        idx = self._idx % self._max_len
-
-        xid, experience = self._buffer[idx]
-        experience = experience._replace(a=a)
-
-        self._buffer[idx] = (xid, experience)
-
     def flush(self):
         self._buffer = {}
         self._idx = 0

--- a/tests/test_LagBuffer.py
+++ b/tests/test_LagBuffer.py
@@ -104,18 +104,3 @@ class TestLagBuffer:
         assert out[2].gamma == 0.
         assert out[2].terminal
         assert np.all(out[2].n_x == 5)
-
-    def test_flush(self):
-        buffer = LagBuffer(lag=1)
-
-        buffer.add(Timestep(
-            x=np.array(0),
-            a=0,
-            r=0,
-            gamma=0,
-            terminal=True,
-        ))
-
-        assert len(buffer._buffer) == 1
-        buffer.flush()
-        assert len(buffer._buffer) == 0


### PR DESCRIPTION
This PR first refactors the lag buffer to incrementally build up n-step transitions, instead of doing the work of computing returns and gammas just before returning.

This incremental build, then, enables the ability to do multi-lag buffers (i.e. return lag 1, lag 2, lag 3, ... from the same buffer).